### PR TITLE
Reorganized (UDef_ARP.py) main and map checker functions

### DIFF
--- a/UDef-ARP.py
+++ b/UDef-ARP.py
@@ -2399,11 +2399,8 @@ class MapChecker:
         self.in_fn=None
 
     def get_image_resolution(self,image):
-        # Set up a GDAL dataset
         in_ds = gdal.Open(image)
-        # Set up a GDAL band
         P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
         return P
 
     def get_image_dimensions(self, image):

--- a/UDef-ARP.py
+++ b/UDef-ARP.py
@@ -197,80 +197,12 @@ class RMT_FIT_CAL_SCREEN(QDialog):
             self.fmask_2 = file_path
             self.fmask_entry_2.setText(file_path.split('/')[-1])
 
-    def get_image_resolution(self,image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                      'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32', 'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
 
     def process_data2_nrt(self):
         images = [self.in_fn, self.deforestation_hrp, self.mask]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
@@ -278,7 +210,7 @@ class RMT_FIT_CAL_SCREEN(QDialog):
         directory = self.folder_entry.text()
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -288,12 +220,12 @@ class RMT_FIT_CAL_SCREEN(QDialog):
             QMessageBox.critical(self, "Error", "Please select all input files!")
             return
 
-        if not self.check_binary_map(self.deforestation_hrp):
+        if not map_checker.check_binary_map(self.deforestation_hrp):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE HRP' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
 
-        if not self.check_binary_map(self.mask):
+        if not map_checker.check_binary_map(self.mask):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate jurisdiction.")
             return
@@ -409,13 +341,13 @@ class RMT_FIT_CAL_SCREEN(QDialog):
         images = [self.in_fn_2, self.mask_2, self.fmask_2]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -437,13 +369,12 @@ class RMT_FIT_CAL_SCREEN(QDialog):
                                  "Please enter .rst or .tif extension in the name of Vulnerability Map in CAL!")
             return
 
-
-        if not self.check_binary_map(self.fmask_2):
+        if not map_checker.check_binary_map(self.fmask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF FOREST AREAS IN THE CAL' must be a binary map (0 and 1) where the 1’s indicate forest areas.")
             return
 
-        if not self.check_binary_map(self.mask_2):
+        if not map_checker.check_binary_map(self.mask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
@@ -562,87 +493,17 @@ class AT_FIT_CAL_Screen(QDialog):
             self.deforestation_hrp = file_path3
             self.deforestation_hrp_entry.setText(file_path3.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data3(self):
         images = [self.risk30_hrp, self.municipality, self.deforestation_hrp]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -684,7 +545,7 @@ class AT_FIT_CAL_Screen(QDialog):
                                  "Please enter .rst or .tif extension in the name for Fitted Density Map in the CAL!")
             return
 
-        if not self.check_binary_map(self.deforestation_hrp):
+        if not map_checker.check_binary_map(self.deforestation_hrp):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE CAL' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
@@ -804,76 +665,6 @@ class MCT_FIT_CAL_Screen(QDialog):
             self.density = file_path
             self.density_entry.setText(file_path.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data4(self):
         images = [self.mask, self.deforestation_hrp, self.density]
 
@@ -884,7 +675,7 @@ class MCT_FIT_CAL_Screen(QDialog):
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -957,12 +748,12 @@ class MCT_FIT_CAL_Screen(QDialog):
                                  "Please enter .rst or .tif extension in the name of Residual Map!")
             return
 
-        if not self.check_binary_map(self.mask):
+        if not map_checker.check_binary_map(self.mask):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
 
-        if not self.check_binary_map(self.deforestation_hrp):
+        if not map_checker.check_binary_map(self.deforestation_hrp):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE CAL' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
@@ -1130,63 +921,6 @@ class RMT_PRE_CNF_SCREEN(QDialog):
             self.fmask_2 = file_path
             self.fmask_entry_2.setText(file_path.split('/')[-1])
 
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data2(self):
         if not self.in_fn:
             QMessageBox.critical(self, "Error", "Please select the input file!")
@@ -1259,31 +993,17 @@ class RMT_PRE_CNF_SCREEN(QDialog):
             self.progressDialog.close()
             QMessageBox.critical(self, "Error", f"An error occurred during processing: {str(e)}")
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
     def process_data2_2(self):
         images = [self.in_fn_2, self.mask_2, self.fmask_2]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -1305,12 +1025,12 @@ class RMT_PRE_CNF_SCREEN(QDialog):
                                  "Please enter .rst or .tif extension in the name of Vulnerability Map in CNF!")
             return
 
-        if not self.check_binary_map(self.fmask_2):
+        if not map_checker.check_binary_map(self.fmask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF FOREST AREAS IN THE CNF' must be a binary map (0 and 1) where the 1’s indicate forest areas.")
             return
 
-        if not self.check_binary_map(self.mask_2):
+        if not map_checker.check_binary_map(self.mask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
@@ -1437,87 +1157,17 @@ class AT_PRE_CNF_Screen(QDialog):
             self.deforestation_cnf = file_path3
             self.deforestation_cnf_entry.setText(file_path3.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data3(self):
         images = [self.municipality, self.deforestation_cnf, self.risk30_vp]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -1559,7 +1209,7 @@ class AT_PRE_CNF_Screen(QDialog):
             QMessageBox.critical(self, "Error", "Max iteration value should be a valid number!")
             return
 
-        if not self.check_binary_map(self.deforestation_cnf):
+        if not map_checker.check_binary_map(self.deforestation_cnf):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE CNF' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
@@ -1699,87 +1349,17 @@ class MCT_PRE_CNF_Screen(QDialog):
             self.density = file_path
             self.density_entry.setText(file_path.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data4(self):
         images = [self.mask, self.fmask, self.deforestation_cal, self.deforestation_hrp, self.density]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -1861,22 +1441,22 @@ class MCT_PRE_CNF_Screen(QDialog):
                                  "Please enter .rst or .tif extension in the name of Combined Deforestation Reference Map!")
             return
 
-        if not self.check_binary_map(self.mask):
+        if not map_checker.check_binary_map(self.mask):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
 
-        if not self.check_binary_map(self.deforestation_hrp):
+        if not map_checker.check_binary_map(self.deforestation_hrp):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE CNF' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
 
-        if not self.check_binary_map(self.deforestation_cal):
+        if not map_checker.check_binary_map(self.deforestation_cal):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE CAL' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
 
-        if not self.check_binary_map(self.fmask):
+        if not map_checker.check_binary_map(self.fmask):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF FOREST AREAS IN THE CAL' must be a binary map (0 and 1) where the 1’s indicate forest areas.")
             return
@@ -2042,62 +1622,6 @@ class RMT_FIT_HRP_SCREEN(QDialog):
             self.fmask_2 = file_path
             self.fmask_entry_2.setText(file_path.split('/')[-1])
 
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data2(self):
         if not self.in_fn:
             QMessageBox.critical(self, "Error", "Please select the input file!")
@@ -2170,31 +1694,17 @@ class RMT_FIT_HRP_SCREEN(QDialog):
             self.progressDialog.close()
             QMessageBox.critical(self, "Error", f"An error occurred during processing: {str(e)}")
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
     def process_data2_2(self):
         images = [self.in_fn_2, self.mask_2, self.fmask_2]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -2216,12 +1726,12 @@ class RMT_FIT_HRP_SCREEN(QDialog):
                                  "Please enter .rst or .tif extension in the name of Vulnerability Map in HRP!")
             return
 
-        if not self.check_binary_map(self.mask_2):
+        if not map_checker.check_binary_map(self.mask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
 
-        if not self.check_binary_map(self.fmask_2):
+        if not map_checker.check_binary_map(self.fmask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF FOREST AREAS IN THE HRP' must be a binary map (0 and 1) where the 1’s indicate forest areas.")
             return
@@ -2334,87 +1844,17 @@ class AT_FIT_HRP_Screen(QDialog):
             self.deforestation_hrp = file_path3
             self.deforestation_hrp_entry.setText(file_path3.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data3(self):
         images = [self.risk30_hrp, self.municipality, self.deforestation_hrp]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -2455,7 +1895,7 @@ class AT_FIT_HRP_Screen(QDialog):
                                  "Please enter .rst or .tif extension in the name of Fitted Density Map in the HRP!")
             return
 
-        if not self.check_binary_map(self.deforestation_hrp):
+        if not map_checker.check_binary_map(self.deforestation_hrp):
             QMessageBox.critical(None, "Error",
                                  "'MAP OF DEFORESTATION IN THE HRP' must be a binary map (0 and 1) where the 1’s indicate deforestation.")
             return
@@ -2613,62 +2053,6 @@ class RMT_PRE_VP_SCREEN(QDialog):
             self.fmask_2 = file_path
             self.fmask_entry_2.setText(file_path.split('/')[-1])
 
-    def get_image_datatype(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        datatype = gdal.GetDataTypeName(in_band.DataType)
-        return datatype
-
-    def get_image_max_min(self, image):
-        in_ds = gdal.Open(image)
-        in_band = in_ds.GetRasterBand(1)
-        min, max= in_band.ComputeRasterMinMax()
-        return min, max
-
-    def find_unique_values(self, arr, limit=2):
-        unique_values = set()
-        for value in np.nditer(arr):
-            unique_values.add(value.item())
-            if len(unique_values) > limit:
-                return False
-        return True
-
-    def check_binary_map(self, in_fn):
-        '''
-        Check if input image is binary map
-        :param in_fn: input image
-        :return: True if the file is a binary map, False otherwise
-        '''
-        file_extension = in_fn.split('.')[-1].lower()
-        file_name, _ = os.path.splitext(in_fn)
-        if file_extension == 'rst':
-            with open(file_name + '.rdc', 'r') as read_file:
-                rdc_content = read_file.read().lower()
-                byte_or_integer_binary = "data type   : byte" in rdc_content or (
-                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
-                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
-        elif file_extension == 'tif':
-            datatype = self.get_image_datatype(in_fn)
-            min_val, max_val = self.get_image_max_min(in_fn)
-            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
-                                                  'UInt32'] and max_val == 1 and min_val == 0
-            float_binary = datatype in ['Float32', 'Float64', 'CFloat32',
-                                        'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
-
-        if byte_or_integer_binary or (float_binary):
-            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
-            if float_binary:
-                in_ds = gdal.Open(in_fn)
-                in_band = in_ds.GetRasterBand(1)
-                arr = in_band.ReadAsArray()
-                # If more than two unique values are found, it's not a binary map, return False.
-                if not self.find_unique_values(arr, 2):
-                    return False
-            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
-            return True
-        # For any other scenario, it returns False.
-        return False
-
     def process_data2(self):
         if not self.in_fn:
             QMessageBox.critical(self, "Error", "Please select the input file!")
@@ -2741,31 +2125,17 @@ class RMT_PRE_VP_SCREEN(QDialog):
             self.progressDialog.close()
             QMessageBox.critical(self, "Error", f"An error occurred during processing: {str(e)}")
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
     def process_data2_2(self):
         images = [self.in_fn_2, self.mask_2, self.fmask_2]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -2787,12 +2157,12 @@ class RMT_PRE_VP_SCREEN(QDialog):
                                  "Please enter .rst or .tif extension in the name of Vulnerability Map in VP!")
             return
 
-        if not self.check_binary_map(self.mask_2):
+        if not map_checker.check_binary_map(self.mask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF THE NON-EXCLUDED JURISDICTION' must be a binary map (0 and 1) where the 1’s indicate areas inside the jurisdiction.")
             return
 
-        if not self.check_binary_map(self.fmask_2):
+        if not map_checker.check_binary_map(self.fmask_2):
             QMessageBox.critical(None, "Error",
                                  "'MASK OF FOREST AREAS IN THE VP' must be a binary map (0 and 1) where the 1’s indicate forest areas.")
             return
@@ -2832,7 +2202,6 @@ class RMT_PRE_VP_SCREEN(QDialog):
         # Update QProgressDialog with the new value
         if self.progressDialog is not None:
             self.progressDialog.setValue(value)
-
 
 class AT_PRE_VP_Screen(QDialog):
     def __init__(self):
@@ -2908,31 +2277,17 @@ class AT_PRE_VP_Screen(QDialog):
             self.risk30_vp = file_path2
             self.risk30_vp_entry.setText(file_path2.split('/')[-1])
 
-    def get_image_resolution(self, image):
-        # Set up a GDAL dataset
-        in_ds = gdal.Open(image)
-        # Set up a GDAL band
-        P = in_ds.GetGeoTransform()[1]
-        # Create Numpy Array1
-        return P
-
-    def get_image_dimensions(self, image):
-        dataset = gdal.Open(image)
-        cols = dataset.RasterXSize
-        rows = dataset.RasterYSize
-        return rows, cols
-
     def process_data3(self):
         images = [self.municipality, self.risk30_vp]
 
         # Check if all images have the same resolution
-        resolutions = [self.get_image_resolution(img) for img in images]
+        resolutions = [map_checker.get_image_resolution(img) for img in images]
         if len(set(resolutions)) != 1:
             QMessageBox.critical(None, "Error", "All the input raster images must have the same spatial resolution!")
             return
 
         # Check if all images have the same number of rows and columns
-        dimensions = [self.get_image_dimensions(img) for img in images]
+        dimensions = [map_checker.get_image_dimensions(img) for img in images]
         if len(set(dimensions)) != 1:
             QMessageBox.critical(None, "Error",
                                  "All the input raster images must have the same number of rows and columns!")
@@ -3037,21 +2392,99 @@ class CentralDataStore:
         self.NRT = None
         self.directory = None
 
-# main
-app = QApplication(sys.argv)
-# Load custom fonts
+class MapChecker:
+    def __init__(self):
+        self.image=None
+        self.arr=None
+        self.in_fn=None
 
-font_id=QFontDatabase.addApplicationFont(str(Path(PureWindowsPath("font\\AvenirNextLTPro-DemiCn.otf"))))
+    def get_image_resolution(self,image):
+        # Set up a GDAL dataset
+        in_ds = gdal.Open(image)
+        # Set up a GDAL band
+        P = in_ds.GetGeoTransform()[1]
+        # Create Numpy Array1
+        return P
 
-intro = IntroScreen()
-# Create a global instance of this store
-central_data_store = CentralDataStore()
-widget = QtWidgets.QStackedWidget()
-widget.addWidget(intro)
-widget.setFixedHeight(1000)
-widget.setFixedWidth(1800)
-widget.show()
-try:
-    sys.exit(app.exec_())
-except:
-    print("Exiting")
+    def get_image_dimensions(self, image):
+        dataset = gdal.Open(image)
+        cols = dataset.RasterXSize
+        rows = dataset.RasterYSize
+        return rows, cols
+
+    def get_image_datatype(self, image):
+        in_ds = gdal.Open(image)
+        in_band = in_ds.GetRasterBand(1)
+        datatype = gdal.GetDataTypeName(in_band.DataType)
+        return datatype
+
+    def get_image_max_min(self, image):
+        in_ds = gdal.Open(image)
+        in_band = in_ds.GetRasterBand(1)
+        min, max= in_band.ComputeRasterMinMax()
+        return min, max
+
+    def find_unique_values(self, arr, limit=2):
+        unique_values = set()
+        for value in np.nditer(arr):
+            unique_values.add(value.item())
+            if len(unique_values) > limit:
+                return False
+        return True
+
+    def check_binary_map(self, in_fn):
+        '''
+        Check if input image is binary map
+        :param in_fn: input image
+        :return: True if the file is a binary map, False otherwise
+        '''
+        file_extension = in_fn.split('.')[-1].lower()
+        file_name, _ = os.path.splitext(in_fn)
+        if file_extension == 'rst':
+            with open(file_name + '.rdc', 'r') as read_file:
+                rdc_content = read_file.read().lower()
+                byte_or_integer_binary = "data type   : byte" in rdc_content or (
+                        "data type   : integer" in rdc_content and "min. value  : 0" in rdc_content and "max. value  : 1" in rdc_content)
+                float_binary = "data type   : real" in rdc_content and "min. value  : 0.0000000" in rdc_content and "max. value  : 1.0000000" in rdc_content
+        elif file_extension == 'tif':
+            datatype = self.get_image_datatype(in_fn)
+            min_val, max_val = self.get_image_max_min(in_fn)
+            byte_or_integer_binary = datatype in ['Byte', 'CInt16', 'CInt32', 'Int16', 'Int32', 'UInt16',
+                                                      'UInt32'] and max_val == 1 and min_val == 0
+            float_binary = datatype in ['Float32', 'Float64', 'CFloat32', 'CFloat64'] and max_val == 1.0000000 and min_val == 0.0000000
+
+        if byte_or_integer_binary or (float_binary):
+            # For float_binary, use find_unique_values function to check if data only have two unique values [0.0000000, 1.0000000].
+            if float_binary:
+                in_ds = gdal.Open(in_fn)
+                in_band = in_ds.GetRasterBand(1)
+                arr = in_band.ReadAsArray()
+                # If more than two unique values are found, it's not a binary map, return False.
+                if not self.find_unique_values(arr, 2):
+                    return False
+            # Binary map: byte_or_integer_binary or float_binary with two unique values [0.0000000, 1.0000000], it returns True.
+            return True
+        # For any other scenario, it returns False.
+        return False
+
+if __name__ == "__main__":
+    # main
+    app = QApplication(sys.argv)
+    # Load custom fonts
+    font_id = QFontDatabase.addApplicationFont(str(Path(PureWindowsPath("font\\AvenirNextLTPro-DemiCn.otf"))))
+
+    intro = IntroScreen()
+    # Create a global instance of this store
+    central_data_store = CentralDataStore()
+    map_checker = MapChecker()
+
+    widget = QtWidgets.QStackedWidget()
+    widget.addWidget(intro)
+    widget.setFixedHeight(1000)
+    widget.setFixedWidth(1800)
+    widget.show()
+
+    try:
+        sys.exit(app.exec_())
+    except:
+        print("Exiting")


### PR DESCRIPTION
This commit reorganizes "main" part of the script to main execution block. It also extracts the functionality of check binary map, image resolution and image dimensions, that were duplicated across multiple classes and reorganizes them into a single standalone class. A global instance of this class is now used across all ui classes. The reorganization improves code maintainability and reusability. 