### PR TITLE
Update vulnerability_map.py

### DIFF
--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -187,7 +187,7 @@ class VulnerabilityMap(QObject):
         arr = in_band.ReadAsArray()
 
         self.progress_updated.emit(10)
-        max_value = in_band.GetMaximum()
+        max_value = np.max(arr)
 
         # Rescaled empirical vulnerability map to a [1.0–2.0] range
         arr_rescale = 1+arr*1/max_value


### PR DESCRIPTION
I'm not sure if this reverted or I never tired the fix, but it doesn't work with my risk maps unless I calculate the max directly with numpy.