### PR TITLE
Update vulnerability_map.py

### DIFF
--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -187,7 +187,11 @@ class VulnerabilityMap(QObject):
         arr = in_band.ReadAsArray()
 
         self.progress_updated.emit(10)
-        max_value = np.max(arr)
+
+        max_value = in_band.GetMaximum()
+        if max_value is None:
+            # Calculate max_value for raster images without metadata
+            max_value = np.max(arr)
 
         # Rescaled empirical vulnerability map to a [1.0–2.0] range
         arr_rescale = 1+arr*1/max_value


### PR DESCRIPTION
Optimize processing for raster images by checking if max_value is None. For images with metadata, skip loading the entire array. Calculate max_value only for images without metadata.