### PR TITLE
fix(vulnerability_map.py): alternative geometric classification

### DIFF
--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -176,14 +176,15 @@ class VulnerabilityMap(QObject):
         n_classes = int(n_classes)
 
         # Calculate common ratio(r)=(LLmax/LLmin)^1/n_classes
-        r = np.power(LL / UL, 1 / n_classes)
+        r = np.power(UL / LL, 1 / n_classes)
 
-        # Create 2D class_array for the areas within the NRT
+        # Create 2D class_array
         class_array = np.array([[i, i + 1] for i in range(n_classes-1, -1, -1)])
-
-        # Calculate UL and LL value for the areas within the NRT
         x = np.power(r, class_array)
-        risk_class = np.multiply(UL, x)
+        risk_class = LL+(UL-(np.multiply(LL, x)))
+
+        # Explicitly set llmin
+        risk_class[0][1] = LL
 
         self.progress_updated.emit(20)
 

--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -201,45 +201,15 @@ class VulnerabilityMap(QObject):
         mask_arr = arr_rescale*mask_arr*fmask_arr
 
         self.progress_updated.emit(30)
-        # Use boolean indexing to reclassification mask_arr value >= LL into risk_class
-        # (e.g., if n_class is 29, class the areas within the NRT into class 2 to 30)
-        # Set the progress_updated.emit() outside the loop to fasten the process
-        mask_arr[(risk_class[0][0] > mask_arr) & (mask_arr >= risk_class[0][1])] = 1
-        mask_arr[(risk_class[1][0] > mask_arr) & (mask_arr >= risk_class[1][1])] = 2
-        mask_arr[(risk_class[2][0] > mask_arr) & (mask_arr >= risk_class[2][1])] = 3
-        mask_arr[(risk_class[3][0] > mask_arr) & (mask_arr >= risk_class[3][1])] = 4
-        mask_arr[(risk_class[4][0] > mask_arr) & (mask_arr >= risk_class[4][1])] = 5
-        self.progress_updated.emit(40)
-        mask_arr[(risk_class[5][0] > mask_arr) & (mask_arr >= risk_class[5][1])] = 6
-        mask_arr[(risk_class[6][0] > mask_arr) & (mask_arr >= risk_class[6][1])] = 7
-        mask_arr[(risk_class[7][0] > mask_arr) & (mask_arr >= risk_class[7][1])] = 8
-        mask_arr[(risk_class[8][0] > mask_arr) & (mask_arr >= risk_class[8][1])] = 9
-        mask_arr[(risk_class[9][0] > mask_arr) & (mask_arr >= risk_class[9][1])] = 10
-        self.progress_updated.emit(50)
-        mask_arr[(risk_class[10][0] > mask_arr) & (mask_arr >= risk_class[10][1])] = 11
-        mask_arr[(risk_class[11][0] > mask_arr) & (mask_arr >= risk_class[11][1])] = 12
-        mask_arr[(risk_class[12][0] > mask_arr) & (mask_arr >= risk_class[12][1])] = 13
-        mask_arr[(risk_class[13][0] > mask_arr) & (mask_arr >= risk_class[13][1])] = 14
-        mask_arr[(risk_class[14][0] > mask_arr) & (mask_arr >= risk_class[14][1])] = 15
-        self.progress_updated.emit(60)
-        mask_arr[(risk_class[15][0] > mask_arr) & (mask_arr >= risk_class[15][1])] = 16
-        mask_arr[(risk_class[16][0] > mask_arr) & (mask_arr >= risk_class[16][1])] = 17
-        mask_arr[(risk_class[17][0] > mask_arr) & (mask_arr >= risk_class[17][1])] = 18
-        mask_arr[(risk_class[18][0] > mask_arr) & (mask_arr >= risk_class[18][1])] = 19
-        mask_arr[(risk_class[19][0] > mask_arr) & (mask_arr >= risk_class[19][1])] = 20
-        self.progress_updated.emit(70)
-        mask_arr[(risk_class[20][0] > mask_arr) & (mask_arr >= risk_class[20][1])] = 21
-        mask_arr[(risk_class[21][0] > mask_arr) & (mask_arr >= risk_class[21][1])] = 22
-        mask_arr[(risk_class[22][0] > mask_arr) & (mask_arr >= risk_class[22][1])] = 23
-        mask_arr[(risk_class[23][0] > mask_arr) & (mask_arr >= risk_class[23][1])] = 24
-        mask_arr[(risk_class[24][0] > mask_arr) & (mask_arr >= risk_class[24][1])] = 25
-        self.progress_updated.emit(80)
-        mask_arr[(risk_class[25][0] > mask_arr) & (mask_arr >= risk_class[25][1])] = 26
-        mask_arr[(risk_class[26][0] > mask_arr) & (mask_arr >= risk_class[26][1])] = 27
-        mask_arr[(risk_class[27][0] > mask_arr) & (mask_arr >= risk_class[27][1])] = 28
-        mask_arr[(risk_class[28][0] > mask_arr) & (mask_arr >= risk_class[28][1])] = 29
-        mask_arr[(risk_class[29][0] > mask_arr) & (mask_arr >= risk_class[29][1])] = 30
-        self.progress_updated.emit(90)
+
+        for i in range(n_classes):
+            upper = risk_class[i][0]
+            lower = risk_class[i][1]
+            mask_arr[(upper > mask_arr) & (mask_arr >= lower)] = i + 1
+            if i % 5 == 0:
+                progress = 40 + (10 * (i // 5))
+                self.progress_updated.emit(progress)
+
         return mask_arr
 
     def array_to_image(self, in_fn, out_fn, data, data_type, nodata=None):


### PR DESCRIPTION
**Refined alternative geometric classification algorithm to correct zone width assignments.**

The original algorithm assigned narrow zones in areas of lowest vulnerability and wider zones in areas of highest vulnerability. This update reverses that logic, ensuring narrow zones are applied to areas of highest vulnerability, with progressively wider zones for lower-vulnerability areas.

According to UDef-A, in the alternative geometric classification, Common Ratio is as follow:
```
Common Ratio(r) = (LLmax/LLmin)^1/n_classes

Where:
r = Common ratio (unitless)
LLmax = Higher limit of the highest vulnerability class (m) = 2
LLmin = Lower limit of the lowest vulnerability class = 1
n_classes = Number of vulnerability classes = 30

r=(2/1)^1/30=~1.02337389199677
```

The alternative geometric classification differs from the original geometric classification, as the class ID increases, the bin width decreases (in contrast to the original geometric classification, where both the class ID and bin width increase). The formula for LLc in alternative geometric classification is as follow : 

```
LLc = LLmin + (LLmax - LLmin) * r^c

Where:
LLc = Lower limit of the cth vulnerability class (m)
LLmax = Higher limit of the highest vulnerability class (m) = 2
LLmin = Lower limit of the lowest vulnerability class = 1
c = Class number (unitless)
r = Common ratio (unitless)
```


**Class Limits of the Final Vulnerability Map**

| Class | LLmin | LLmax |
|----------|----------|----------|
| 1    | 1  | 1.0456800631315044   |
| 2  |   1.0456800631315044 | 1.0903167921791634 |   
| 3  |  1.0903167921791634| 1.1339340169263818  |  
| 4  |  1.1339340169263818| 1.1765550228835633  |   
| 5  |  1.1765550228835633| 1.2182025637193186  |   
| 6  |  1.2182025637193186| 1.258898873407749  |    
| 7  |  1.258898873407749| 1.2986656780982861  |   
| 8  | 1.2986656780982861| 1.337524207714422   |   
| 9  |  1.337524207714422| 1.3754952072875268  |   
|  10 |  1.3754952072875268| 1.4125989480317984  |    
| 11  | 1.4125989480317984|1.4488552381662634   |   
| 12  |  1.4488552381662634| 1.4842834334896002  |   
|  13 |  1.4842834334896002| 1.518902447713434  |    
| 14  | 1.518902447713434| 1.5527307625596205   |    
| 15  |  1.5527307625596205| 1.5857864376269035  |    
| 16  | 1.5857864376269035|1.6180871200322227   |    
| 17  | 1.6180871200322227| 1.6496500538318088   |    
| 18  |  1.6496500538318088|1.6804920892271047  |    
| 19  |  1.6804920892271047| 1.71062969156042  |    
| 20  | 1.71062969156042| 1.740078950105126   |    
| 21  | 1.740078950105126| 1.768855586655083   |    
|  22 | 1.768855586655083| 1.7969749639178827   |    
| 23  | 1.7969749639178827| 1.8244520937163908   |    
| 24  |  1.8244520937163908|1.8513016450029645  |    
| 25  | 1.8513016450029645| 1.8775379516906268   |    
| 26  | 1.8775379516906268| 1.9031750203053737  |    
| 27  | 1.9031750203053737|1.9282265374637066   |    
| 28  | 1.9282265374637066| 1.952705877179373   |    
|29   | 1.952705877179373|1.976626108003225   |    
| 30  |1.976626108003225    | 2.0    |