### PR TITLE
Fix replace_ref_system function when input is tif and output is rst

### DIFF
--- a/allocation_tool.py
+++ b/allocation_tool.py
@@ -384,7 +384,6 @@ class AllocationTool(QObject):
 
                     # Move the temp file to replace the original
                     shutil.move(temp_file_path, write_file_name + '.rdc')
-                    self.progress_updated.emit(100)
 
             elif in_fn.split('.')[-1] == 'tif':
                 # Read projection information from the .tif file using GDAL
@@ -406,10 +405,6 @@ class AllocationTool(QObject):
                             write_file.write(line)
 
                 shutil.move(temp_file_path, write_file_name + '.rdc')
-                self.progress_updated.emit(100)
-            else:
-                self.progress_updated.emit(100)
-
 
     def execute_workflow_fit(self, directory,risk30_hrp,municipality, deforestation_hrp, csv_name, out_fn1, out_fn2):
         '''

--- a/allocation_tool.py
+++ b/allocation_tool.py
@@ -363,26 +363,52 @@ class AllocationTool(QObject):
          :param out_fn: rst raster file
         '''
         if out_fn.split('.')[-1] == 'rst':
-            read_file_name, _ = os.path.splitext(in_fn)
-            write_file_name, _ = os.path.splitext(out_fn)
-            temp_file_path = 'rdc_temp.rdc'
+            if in_fn.split('.')[-1] == 'rst':
+                read_file_name, _ = os.path.splitext(in_fn)
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
 
-            with open(read_file_name + '.rdc', 'r') as read_file:
-                for line in read_file:
-                    if line.startswith("ref. system :"):
-                        correct_name=line
-                        break
+                with open(read_file_name + '.rdc', 'r') as read_file:
+                    for line in read_file:
+                        if line.startswith("ref. system :"):
+                            correct_name = line
+                            break
 
-            if correct_name:
+                if correct_name:
+                    with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
+                        for line in read_file:
+                            if line.startswith("ref. system :"):
+                                write_file.write(correct_name)
+                            else:
+                                write_file.write(line)
+
+                    # Move the temp file to replace the original
+                    shutil.move(temp_file_path, write_file_name + '.rdc')
+                    self.progress_updated.emit(100)
+
+            elif in_fn.split('.')[-1] == 'tif':
+                # Read projection information from the .tif file using GDAL
+                dataset = gdal.Open(in_fn)
+                projection = dataset.GetProjection()
+                dataset = None
+
+                # Extract the reference system name from the wkt projection
+                ref_system_name = projection.split('PROJCS["')[1].split('"')[0]
+
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
+
                 with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
                     for line in read_file:
                         if line.startswith("ref. system :"):
-                            write_file.write(correct_name)
+                            write_file.write(f"ref. system : {ref_system_name}\n")
                         else:
                             write_file.write(line)
 
-                # Move the temp file to replace the original
                 shutil.move(temp_file_path, write_file_name + '.rdc')
+                self.progress_updated.emit(100)
+            else:
+                self.progress_updated.emit(100)
 
 
     def execute_workflow_fit(self, directory,risk30_hrp,municipality, deforestation_hrp, csv_name, out_fn1, out_fn2):

--- a/model_evaluation.py
+++ b/model_evaluation.py
@@ -77,26 +77,52 @@ class ModelEvaluation(QObject):
          :param out_fn: rst raster file
         '''
         if out_fn.split('.')[-1] == 'rst':
-            read_file_name, _ = os.path.splitext(in_fn)
-            write_file_name, _ = os.path.splitext(out_fn)
-            temp_file_path = 'rdc_temp.rdc'
+            if in_fn.split('.')[-1] == 'rst':
+                read_file_name, _ = os.path.splitext(in_fn)
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
 
-            with open(read_file_name + '.rdc', 'r') as read_file:
-                for line in read_file:
-                    if line.startswith("ref. system :"):
-                        correct_name=line
-                        break
+                with open(read_file_name + '.rdc', 'r') as read_file:
+                    for line in read_file:
+                        if line.startswith("ref. system :"):
+                            correct_name = line
+                            break
 
-            if correct_name:
+                if correct_name:
+                    with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
+                        for line in read_file:
+                            if line.startswith("ref. system :"):
+                                write_file.write(correct_name)
+                            else:
+                                write_file.write(line)
+
+                    # Move the temp file to replace the original
+                    shutil.move(temp_file_path, write_file_name + '.rdc')
+                    self.progress_updated.emit(100)
+
+            elif in_fn.split('.')[-1] == 'tif':
+                # Read projection information from the .tif file using GDAL
+                dataset = gdal.Open(in_fn)
+                projection = dataset.GetProjection()
+                dataset = None
+
+                # Extract the reference system name from the wkt projection
+                ref_system_name = projection.split('PROJCS["')[1].split('"')[0]
+
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
+
                 with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
                     for line in read_file:
                         if line.startswith("ref. system :"):
-                            write_file.write(correct_name)
+                            write_file.write(f"ref. system : {ref_system_name}\n")
                         else:
                             write_file.write(line)
 
-                # Move the temp file to replace the original
                 shutil.move(temp_file_path, write_file_name + '.rdc')
+                self.progress_updated.emit(100)
+            else:
+                self.progress_updated.emit(100)
 
     def replace_legend(self, out_fn):
         '''

--- a/model_evaluation.py
+++ b/model_evaluation.py
@@ -98,7 +98,6 @@ class ModelEvaluation(QObject):
 
                     # Move the temp file to replace the original
                     shutil.move(temp_file_path, write_file_name + '.rdc')
-                    self.progress_updated.emit(100)
 
             elif in_fn.split('.')[-1] == 'tif':
                 # Read projection information from the .tif file using GDAL
@@ -120,9 +119,6 @@ class ModelEvaluation(QObject):
                             write_file.write(line)
 
                 shutil.move(temp_file_path, write_file_name + '.rdc')
-                self.progress_updated.emit(100)
-            else:
-                self.progress_updated.emit(100)
 
     def replace_legend(self, out_fn):
         '''

--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -247,24 +247,49 @@ class VulnerabilityMap(QObject):
          :param out_fn: rst raster file
         '''
         if out_fn.split('.')[-1] == 'rst':
-            read_file_name, _ = os.path.splitext(in_fn)
-            write_file_name, _ = os.path.splitext(out_fn)
-            temp_file_path = 'rdc_temp.rdc'
+            if in_fn.split('.')[-1] == 'rst':
+                read_file_name, _ = os.path.splitext(in_fn)
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
 
-            with open(read_file_name + '.rdc', 'r') as read_file:
-                for line in read_file:
-                    if line.startswith("ref. system :"):
-                        correct_name=line
-                        break
+                with open(read_file_name + '.rdc', 'r') as read_file:
+                    for line in read_file:
+                        if line.startswith("ref. system :"):
+                            correct_name = line
+                            break
 
-            if correct_name:
+                if correct_name:
+                    with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
+                        for line in read_file:
+                            if line.startswith("ref. system :"):
+                                write_file.write(correct_name)
+                            else:
+                                write_file.write(line)
+
+                    # Move the temp file to replace the original
+                    shutil.move(temp_file_path, write_file_name + '.rdc')
+                    self.progress_updated.emit(100)
+
+            elif in_fn.split('.')[-1] == 'tif':
+                # Read projection information from the .tif file using GDAL
+                dataset = gdal.Open(in_fn)
+                projection = dataset.GetProjection()
+                dataset = None
+
+                # Extract the reference system name from the wkt projection
+                ref_system_name = projection.split('PROJCS["')[1].split('"')[0]
+
+                write_file_name, _ = os.path.splitext(out_fn)
+                temp_file_path = 'rdc_temp.rdc'
+
                 with open(write_file_name + '.rdc', 'r') as read_file, open(temp_file_path, 'w') as write_file:
                     for line in read_file:
                         if line.startswith("ref. system :"):
-                            write_file.write(correct_name)
+                            write_file.write(f"ref. system : {ref_system_name}\n")
                         else:
                             write_file.write(line)
 
-                # Move the temp file to replace the original
                 shutil.move(temp_file_path, write_file_name + '.rdc')
+                self.progress_updated.emit(100)
+            else:
                 self.progress_updated.emit(100)


### PR DESCRIPTION
Modified the ```replace_ref_system``` function in ```vulnerability_map.py```, ```allocation_tool.py```, and ```model_evaluation.py``` to handle scenarios where the output data format is ```rst``` and the input format is ```tif```. The revised version copies the projection from the ```tif``` WKT and corrects the projection system name in the ```rdc``` file.