### PR TITLE
Update (mct_pre_screen.ui) : Corrected Label Wording

### DIFF
--- a/data/mct_pre_cnf_screen.ui
+++ b/data/mct_pre_cnf_screen.ui
@@ -284,7 +284,7 @@ color: rgb(125, 169, 172);
          <string notr="true">font: 10pt&quot;AvenirNext LT Pro Cn&quot;;</string>
         </property>
         <property name="text">
-         <string>Adjusted Predicted Density in the CHF</string>
+         <string>Adjusted Predicted Density in the CNF</string>
         </property>
        </widget>
        <widget class="QLabel" name="label_3">


### PR DESCRIPTION
Corrected wording from 'Adjusted Predicted Density in the CHF' to 'Adjusted Predicted Density in the CNF