### PR TITLE
Update (vulnerability_map.py) : Removed int() in line 67

### DIFF
--- a/vulnerability_map.py
+++ b/vulnerability_map.py
@@ -64,7 +64,7 @@ class VulnerabilityMap(QObject):
         # Set up bin width as spatial resolution
         in_ds = gdal.Open(in_fn)
         P = in_ds.GetGeoTransform()[1]
-        bin_width =int(P)
+        bin_width = P
         # Calculate the histogram
         hist, bin_edges = np.histogram(distance_arr_masked_1d, bins=np.arange(distance_arr_masked_1d.min(),
                                                                               distance_arr_masked_1d.max() + bin_width,


### PR DESCRIPTION
Line 67: Removed int() for resolution in the nrt_calculation function to prevent issue when spatial resolution is smaller than one.