### PR TITLE
Changed (allocation_tool.py): Preserve Original CSV Name and Rename Adjusted File for Prediction

### DIFF
--- a/allocation_tool.py
+++ b/allocation_tool.py
@@ -577,8 +577,5 @@ class AllocationTool(QObject):
         # Drop column 'v_zone'
         df_new=df_new.drop(['v_zone'], axis=1)
 
-        # Copy the original csv file copy and rename it to csv_orig
-        shutil.copyfile(csv, csv.split('.')[0] + '_orig' + '.csv')
-
         # Save the new result to csv
-        df_new.to_csv(csv, index=False)
+        df_new.to_csv(csv.split('.')[0] + '_adjusted_for_prediction' + '.csv', index=False)


### PR DESCRIPTION
Updated the script to retain the original CSV file name and rename the adjusted CSV file as csv_adjusted_for_prediction. This change ensures the original file remains unchanged while clearly distinguishing the adjusted version.